### PR TITLE
Remove unavailable measure mode

### DIFF
--- a/lib/fluent/rubyprof.rb
+++ b/lib/fluent/rubyprof.rb
@@ -69,7 +69,7 @@ module Fluent
         raise OptionParser::InvalidOption.new("`start` or `stop` must be specified as the 1st argument")
       end
 
-      measure_modes = %w[PROCESS_TIME WALL_TIME CPU_TIME ALLOCATIONS MEMORY GC_RUNS GC_TIME] 
+      measure_modes = %w[PROCESS_TIME WALL_TIME ALLOCATIONS MEMORY]
       unless measure_modes.include?(opts[:measure_mode])
         raise OptionParser::InvalidOption.new("-m allows one of #{measure_modes.join(', ')}")
       end

--- a/spec/fluent-rubyprof/rubyprof_spec.rb
+++ b/spec/fluent-rubyprof/rubyprof_spec.rb
@@ -13,7 +13,7 @@ describe Fluent::Rubyprof do
     end
 
     it 'correct measure_mode' do
-      expect { Fluent::Rubyprof.new.parse_options(['start', '-m', 'CPU_TIME']) }.not_to raise_error
+      expect { Fluent::Rubyprof.new.parse_options(['start', '-m', 'PROCESS_TIME']) }.not_to raise_error
     end
 
     it 'incorrect measure_mode' do


### PR DESCRIPTION
Since ruby-prof 1.0.0 (2019-07-29), the followings measurement
options were removed.

* CPU_TIME
* GC_TIME
* GC_RUNS

ref. https://github.com/ruby-prof/ruby-prof/blob/master/CHANGES#L55